### PR TITLE
Support CORS headers via flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ the ChirpStack Application Server.
 ## Usage
 
 ```bash
-chirpstack-rest-api --server localhost:8080 --bind 0.0.0.0:8090 --insecure
+chirpstack-rest-api --server localhost:8080 --bind 0.0.0.0:8090 --insecure --cors "*"
 ```
 
 * `--server` points to the ChirpStack gRPC endpoint. If ChirpStack is installed
@@ -21,6 +21,7 @@ chirpstack-rest-api --server localhost:8080 --bind 0.0.0.0:8090 --insecure
 * `--insecure` indicates that the gRPC interface is not secured using a TLS
   certificate. You can also use the environment variable `INSECURE` (setting
   this to any value enables insecure mode, e.g. do not use `INSECURE=false`!).
+* `--cors` defines the CORS policy by setting the AllowedOrigins Header. You can also use the environment variable `CORS`. `--cors "*"` allows all origins. Default is `--cors 0.0.0.0` which disables CORS.
 
 ## Building from source
 

--- a/go.mod
+++ b/go.mod
@@ -71,6 +71,7 @@ require (
 	github.com/dghubble/sling v1.4.0 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-git/go-git/v5 v5.4.2 // indirect
@@ -89,6 +90,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.1.0 // indirect
 	github.com/goreleaser/chglog v0.1.2 // indirect
 	github.com/goreleaser/fileglob v1.3.0 // indirect
+	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -274,6 +274,8 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
@@ -435,6 +437,8 @@ github.com/goreleaser/goreleaser v1.10.2 h1:MxgA0hDbDbTLep0u3pnu7Uh1Q1p0q60mpb88
 github.com/goreleaser/goreleaser v1.10.2/go.mod h1:i+eGc/m/nN2aV/O00zCNP67H2m+ePuQfVOcUcmrhjcU=
 github.com/goreleaser/nfpm/v2 v2.16.0 h1:RtItVwSL3xqe698CkmIOfiQh4/BQANIa4yvyBERrNeo=
 github.com/goreleaser/nfpm/v2 v2.16.0/go.mod h1:NlB1cCZj68NG7ZJA6eJ1dSeX3V0UWfw30itwHvT6HPw=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=


### PR DESCRIPTION
With this changes it is possible to configure the `AllowedOrigins Header` for all routes. For example setting the header to "*" it allows requests from all origins. 

I think this is needed and helpful if you want to request from frontend application without using any proxy. 

- [x] set up a flag to support setting the AllowedOrigins Header
- [x] update Readme
- [x] added fmt print at Start of the server



Also see: https://forum.chirpstack.io/t/cors-error-while-hitting-apis-from-react-application/14890/2
